### PR TITLE
Configura CI com H2 para testes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ build/
 
 ### VS Code ###
 .vscode/
+
+src/main/resources/application-local.properties

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,12 @@
 		</dependency>
 
 		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>com.auth0</groupId>
 			<artifactId>java-jwt</artifactId>
 			<version>4.4.0</version>

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,0 +1,3 @@
+spring.datasource.url=jdbc:postgresql://localhost:5432/products-api
+spring.datasource.username=postgres
+spring.datasource.password=post

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,8 @@
-spring.datasource.url=jdbc:postgresql://localhost:5432/your-database-name
-spring.datasource.username=your-username
-spring.datasource.password=your-password
+# Configurações gerais (usadas por padrão)
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
+api.security.token.secret=${JWT_SECRET:my-secret-key}
+
+# Perfil "local" para desenvolvimento com PostgreSQL
+---
+spring.profiles.active=local

--- a/src/test/java/com/example/springboot/SpringbootApplicationTests.java
+++ b/src/test/java/com/example/springboot/SpringbootApplicationTests.java
@@ -2,8 +2,10 @@ package com.example.springboot;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class SpringbootApplicationTests {
 
 	@Test

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,0 +1,10 @@
+# Configurações do H2
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=password
+
+# Configurações do Hibernate/JPA
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true


### PR DESCRIPTION
Adiciona suporte ao banco de dados H2 em memória para execução de testes no CI.
- Adiciona dependência do H2 no pom.xml.
- Cria arquivo application-test.properties para configurações do H2.
- Ativa perfil 'test' na classe SpringbootApplicationTests.